### PR TITLE
Add ejudge client integration layer

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -37,6 +37,8 @@ All handlers use async sessions to interact with the database. Responses are sim
 
 ### Ejudge integration primitives
 - **Typed schema hub:** `backend/ejudge/models.py` centralises the Pydantic models describing the `submit-run`, `submit-run-input`, `get-submit`, and `get-user` endpoints, plus the supporting notification structures.
+- **Async HTTP wrapper:** `backend/ejudge/client.py` exposes `EjudgeClient`, an async helper that translates the models into correctly encoded HTTP requests (form, multipart, or query string) and validates responses. It normalises authentication headers (`Authorization: Bearer AQAA<TOKEN>`), forces `json=1` semantics, and raises rich exceptions (`EjudgeClientError`, `EjudgeReplyError`) for both transport failures and `ok=false` replies.
+- **Testing & mocks:** `backend/ejudge/mocks.py` supplies canned Pydantic reply builders and `create_mock_transport`, letting unit tests stand up a fully in-memory ejudge double via `httpx.MockTransport` while asserting on the emitted requests.
 - **Usage guidance:** the models enforce mutually exclusive fields (problem selector, language selector, payload inputs) via validators so client code cannot accidentally craft invalid multipart requests.
 - **Autonomy-friendly docs:** the module includes detailed field annotations and docstrings explaining how each value maps to the upstream wiki and Swagger specification, enabling AI agents to extend the integration safely without re-reading the raw JSON spec.
 

--- a/backend/ejudge/__init__.py
+++ b/backend/ejudge/__init__.py
@@ -1,5 +1,15 @@
-"""Typed primitives for the ejudge integration layer."""
+"""Typed primitives and HTTP helpers for the ejudge integration layer."""
 
+from .client import EjudgeClient, EjudgeClientError, EjudgeReplyError
+from .mocks import (
+    RecordedCall,
+    create_mock_transport,
+    make_get_submit_reply,
+    make_get_user_reply,
+    make_submit_details,
+    make_submit_run_input_reply,
+    make_submit_run_reply,
+)
 from .models import (
     EjudgeError,
     EjudgeReply,
@@ -17,17 +27,27 @@ from .models import (
 )
 
 __all__ = [
+    'EjudgeClient',
+    'EjudgeClientError',
     'EjudgeError',
     'EjudgeReply',
+    'EjudgeReplyError',
     'GetSubmitReply',
     'GetSubmitRequest',
     'GetUserReply',
     'GetUserRequest',
     'NotificationKind',
     'NotificationTarget',
+    'RecordedCall',
     'SubmitDetails',
     'SubmitRunInputReply',
     'SubmitRunInputRequest',
     'SubmitRunReply',
     'SubmitRunRequest',
+    'create_mock_transport',
+    'make_get_submit_reply',
+    'make_get_user_reply',
+    'make_submit_details',
+    'make_submit_run_input_reply',
+    'make_submit_run_reply',
 ]

--- a/backend/ejudge/client.py
+++ b/backend/ejudge/client.py
@@ -1,0 +1,225 @@
+"""Async HTTP client wrappers around the ejudge API.
+
+The module exposes :class:`EjudgeClient` - a thin but fully typed facade that
+translates our Pydantic request models into ``httpx`` calls and validates the
+JSON replies documented in ``backend/ejudge/doc.json``.  It intentionally
+keeps the I/O surface extremely small (one POST endpoint and two GET
+endpoints) so that service code can reason about ejudge interactions without
+sprinkling low-level HTTP glue everywhere.
+
+The helpers defined here are deliberately chatty in their docstrings to serve
+as inline documentation for future autonomous agents.  When the integration
+grows beyond a single file, these notes should migrate to ``ARCHITECTURE.md``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, MutableMapping
+from dataclasses import dataclass
+from typing import Any, TypeVar
+
+import httpx
+from pydantic import ValidationError
+
+from .models import (
+    EjudgeError,
+    EjudgeReply,
+    GetSubmitReply,
+    GetSubmitRequest,
+    GetUserReply,
+    GetUserRequest,
+    SubmitRunInputReply,
+    SubmitRunInputRequest,
+    SubmitRunReply,
+    SubmitRunRequest,
+)
+
+ReplyT = TypeVar('ReplyT', bound=EjudgeReply[Any])
+
+
+class EjudgeClientError(RuntimeError):
+    """Base error raised for transport or validation failures."""
+
+
+class EjudgeReplyError(EjudgeClientError):
+    """Wrap an ``ok = false`` ejudge reply to provide better context upstream."""
+
+    def __init__(self, reply: EjudgeReply[Any]):
+        self.reply = reply
+        error = reply.error or EjudgeError(num=-1, symbol='unknown', message='No error payload provided by ejudge.')
+        message = f'ejudge reported error {error.symbol} ({error.num}): {error.message or "no message"}'
+        super().__init__(message)
+
+
+@dataclass(slots=True)
+class _FormPayload:
+    """Internal representation of multipart/x-www-form-urlencoded payloads."""
+
+    data: MutableMapping[str, str]
+    files: MutableMapping[str, tuple[str, bytes | str]]
+
+
+def _stringify(value: Any) -> str:
+    if isinstance(value, bool):
+        return '1' if value else '0'
+    return str(value)
+
+
+def _prepare_submit_run_payload(request: SubmitRunRequest) -> _FormPayload:
+    payload = request.model_dump(mode='json', by_alias=True, exclude_none=True)
+    payload.pop('action', None)
+
+    data: MutableMapping[str, str] = {}
+    files: MutableMapping[str, tuple[str, bytes | str]] = {}
+
+    source_bytes = payload.pop('file', None)
+    source_text = payload.pop('text_form', None)
+    if source_bytes is not None:
+        files['file'] = ('solution', source_bytes)
+    if source_text is not None:
+        data['text_form'] = source_text
+
+    for key, value in payload.items():
+        data[key] = _stringify(value)
+
+    return _FormPayload(data=data, files=files)
+
+
+def _prepare_submit_run_input_payload(request: SubmitRunInputRequest) -> _FormPayload:
+    payload = request.model_dump(mode='json', by_alias=True, exclude_none=True)
+    payload.pop('action', None)
+
+    data: MutableMapping[str, str] = {}
+    files: MutableMapping[str, tuple[str, bytes | str]] = {}
+
+    source_bytes = payload.pop('file', None)
+    source_text = payload.pop('text_form', None)
+    if source_bytes is not None:
+        files['file'] = ('solution', source_bytes)
+    if source_text is not None:
+        data['text_form'] = source_text
+
+    stdin_bytes = payload.pop('file_input', None)
+    stdin_text = payload.pop('text_form_input', None)
+    if stdin_bytes is not None:
+        files['file_input'] = ('stdin', stdin_bytes)
+    if stdin_text is not None:
+        data['text_form_input'] = stdin_text
+
+    for key, value in payload.items():
+        data[key] = _stringify(value)
+
+    return _FormPayload(data=data, files=files)
+
+
+class EjudgeClient:
+    """High-level helper for calling the subset of ejudge HTTP API we rely on."""
+
+    def __init__(
+        self,
+        base_url: str,
+        api_token: str,
+        *,
+        endpoint: str = '',
+        timeout: float | httpx.Timeout | None = 10.0,
+        transport: httpx.BaseTransport | None = None,
+        http_client: httpx.AsyncClient | None = None,
+    ) -> None:
+        if http_client is not None and transport is not None:
+            msg = 'Pass either `transport` or a pre-configured `http_client`, not both.'
+            raise ValueError(msg)
+
+        self._authorization = f'Bearer AQAA{api_token}'
+        self._endpoint = endpoint
+        self._own_client = http_client is None
+        if http_client is None:
+            self._client = httpx.AsyncClient(base_url=base_url, timeout=timeout, transport=transport)
+        else:
+            self._client = http_client
+
+    async def __aenter__(self) -> EjudgeClient:
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        await self.aclose()
+
+    async def aclose(self) -> None:
+        if self._own_client:
+            await self._client.aclose()
+
+    # -- Public API -----------------------------------------------------
+
+    async def submit_run(self, request: SubmitRunRequest) -> SubmitRunReply:
+        payload = _prepare_submit_run_payload(request)
+        response = await self._request('POST', request.action, data=payload.data, files=payload.files)
+        return self._parse_reply(response, SubmitRunReply)
+
+    async def submit_run_input(self, request: SubmitRunInputRequest) -> SubmitRunInputReply:
+        payload = _prepare_submit_run_input_payload(request)
+        response = await self._request('POST', request.action, data=payload.data, files=payload.files)
+        return self._parse_reply(response, SubmitRunInputReply)
+
+    async def get_submit(self, request: GetSubmitRequest) -> GetSubmitReply:
+        params = request.model_dump(mode='json', by_alias=True, exclude_none=True)
+        return self._parse_reply(await self._request('GET', request.action, params=params), GetSubmitReply)
+
+    async def get_user(self, request: GetUserRequest) -> GetUserReply:
+        params = request.model_dump(mode='json', by_alias=True, exclude_none=True)
+        return self._parse_reply(await self._request('GET', request.action, params=params), GetUserReply)
+
+    # -- Internal helpers -----------------------------------------------
+
+    async def _request(
+        self,
+        method: str,
+        action: str,
+        *,
+        params: Mapping[str, Any] | None = None,
+        data: Mapping[str, Any] | None = None,
+        files: Mapping[str, tuple[str, bytes | str]] | None = None,
+    ) -> httpx.Response:
+        request_params = {'json': '1', 'action': action}
+        if params:
+            request_params.update({key: _stringify(value) for key, value in params.items() if value is not None})
+
+        headers = {'Authorization': self._authorization}
+
+        try:
+            response = await self._client.request(
+                method,
+                self._endpoint,
+                params=request_params,
+                data=data,
+                files=files if files else None,
+                headers=headers,
+            )
+            response.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            msg = f'ejudge returned unexpected HTTP status {exc.response.status_code} for action {action!r}'
+            raise EjudgeClientError(msg) from exc
+        except httpx.HTTPError as exc:  # Network / protocol problems
+            msg = f'Error communicating with ejudge while performing action {action!r}'
+            raise EjudgeClientError(msg) from exc
+
+        return response
+
+    def _parse_reply(self, response: httpx.Response, model: type[ReplyT]) -> ReplyT:
+        try:
+            payload = response.json()
+        except ValueError as exc:
+            msg = 'ejudge response did not contain valid JSON payload.'
+            raise EjudgeClientError(msg) from exc
+
+        try:
+            parsed = model.model_validate(payload)
+        except ValidationError as exc:
+            msg = f'Unable to validate ejudge response as {model.__name__}.'
+            raise EjudgeClientError(msg) from exc
+
+        if not parsed.ok:
+            raise EjudgeReplyError(parsed)
+
+        return parsed
+
+
+__all__ = ['EjudgeClient', 'EjudgeClientError', 'EjudgeReplyError']

--- a/backend/ejudge/mocks.py
+++ b/backend/ejudge/mocks.py
@@ -1,0 +1,134 @@
+"""Light-weight helpers to mock ejudge for unit tests."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping, MutableMapping
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+
+from .models import (
+    GetSubmitReply,
+    GetUserReply,
+    SubmitDetails,
+    SubmitRunInputReply,
+    SubmitRunInputResult,
+    SubmitRunReply,
+    SubmitRunResult,
+    UserProfile,
+)
+
+
+@dataclass(slots=True)
+class RecordedCall:
+    """Simple container capturing an outgoing request for assertions."""
+
+    method: str
+    url: httpx.URL
+    headers: httpx.Headers
+    content: bytes
+
+
+def _coerce_payload(value: Any) -> tuple[int, Mapping[str, Any]]:
+    status_code = 200
+    payload = value
+    if isinstance(value, tuple) and len(value) == 2 and isinstance(value[0], int):
+        status_code, payload = value
+
+    if hasattr(payload, 'model_dump_json'):
+        data = json.loads(payload.model_dump_json(by_alias=True, exclude_none=True))
+    elif isinstance(payload, Mapping):
+        data = dict(payload)
+    else:
+        msg = 'Mock payloads must be Pydantic models, dicts or (status, payload) tuples.'
+        raise TypeError(msg)
+
+    return status_code, data
+
+
+def create_mock_transport(
+    *,
+    submit_run: Any | None = None,
+    submit_run_input: Any | None = None,
+    get_submit: Any | None = None,
+    get_user: Any | None = None,
+) -> tuple[httpx.MockTransport, list[RecordedCall]]:
+    """Create an :class:`httpx.MockTransport` returning canned ejudge replies."""
+
+    responses: MutableMapping[str, tuple[int, Mapping[str, Any]]] = {}
+    if submit_run is not None:
+        responses['submit-run'] = _coerce_payload(submit_run)
+    if submit_run_input is not None:
+        responses['submit-run-input'] = _coerce_payload(submit_run_input)
+    if get_submit is not None:
+        responses['get-submit'] = _coerce_payload(get_submit)
+    if get_user is not None:
+        responses['get-user'] = _coerce_payload(get_user)
+
+    calls: list[RecordedCall] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        content = request.content
+        recorded = RecordedCall(method=request.method, url=request.url, headers=httpx.Headers(request.headers), content=content)
+        calls.append(recorded)
+
+        action = request.url.params.get('action')
+        if action is None:
+            return httpx.Response(400, json={'ok': False, 'error': {'symbol': 'missing-action'}})
+
+        status_and_payload = responses.get(action)
+        if status_and_payload is None:
+            return httpx.Response(404, json={'ok': False, 'error': {'symbol': 'unhandled-action', 'message': action}})
+
+        status_code, payload = status_and_payload
+        return httpx.Response(status_code, json=payload)
+
+    return httpx.MockTransport(handler), calls
+
+
+def make_submit_run_reply(*, run_id: int = 100, run_uuid: str | None = None) -> SubmitRunReply:
+    return SubmitRunReply(ok=True, action='submit-run', result=SubmitRunResult(run_id=run_id, run_uuid=run_uuid))
+
+
+def make_submit_run_input_reply(*, submit_id: int = 200) -> SubmitRunInputReply:
+    return SubmitRunInputReply(ok=True, action='submit-run-input', result=SubmitRunInputResult(submit_id=submit_id))
+
+
+def make_submit_details(*, submit_id: int = 300, status: int = 0, status_str: str = 'OK') -> SubmitDetails:
+    return SubmitDetails(
+        submit_id=submit_id,
+        user_id=1,
+        prob_id=1,
+        lang_id=1,
+        status=status,
+        status_str=status_str,
+        exit_code=0,
+        term_signal=0,
+    )
+
+
+def make_get_submit_reply(details: SubmitDetails | None = None) -> GetSubmitReply:
+    details = details or make_submit_details()
+    return GetSubmitReply(ok=True, action='get-submit', result=details)
+
+
+def make_user_profile(*, user_id: int = 1, user_login: str = 'user') -> UserProfile:
+    return UserProfile(user_id=user_id, user_login=user_login)
+
+
+def make_get_user_reply(profile: UserProfile | None = None) -> GetUserReply:
+    profile = profile or make_user_profile()
+    return GetUserReply(ok=True, action='get-user', result=profile)
+
+
+__all__ = [
+    'RecordedCall',
+    'create_mock_transport',
+    'make_get_submit_reply',
+    'make_get_user_reply',
+    'make_submit_details',
+    'make_submit_run_input_reply',
+    'make_submit_run_reply',
+]

--- a/backend/ejudge/models.py
+++ b/backend/ejudge/models.py
@@ -10,11 +10,10 @@ extend the integration without re-reading the spec from scratch.
 
 from __future__ import annotations
 
-from typing import Annotated, Literal, TypeVar
+from typing import Annotated, Any, Literal
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field, IPvAnyAddress, model_validator
-from pydantic.generics import GenericModel
 
 # -- Shared scalar aliases --------------------------------------------------
 # Using ``Annotated`` adds validation metadata directly on the types and keeps
@@ -71,20 +70,20 @@ class SubmitRunRequest(EjudgeBaseModel):
     sender_user_id: Annotated[UserId | None, Field(description='Alternative numeric identifier for impersonated submissions.')] = None
     sender_ip: Annotated[IPvAnyAddress | None, Field(description='Original client IP address, if the submitter is proxied.')] = None
     sender_ssl_flag: Annotated[bool | None, Field(description='Set to ``True`` when the user submitted via HTTPS.')] = None
-    problem_uuid: Annotated[UUID | None, Field(description='UUID of the problem to target. Mutually exclusive with ``problem_name`` and ``problem``.')]
-    problem_name: Annotated[str | None, Field(description='Problem short or internal name. Mutually exclusive with ``problem_uuid`` and ``problem``.')]
-    problem: Annotated[ProblemId | None, Field(description='Numeric problem identifier. Mutually exclusive with the other problem selectors.')]
-    variant: Annotated[int | None, Field(description='Optional variant identifier for variant-aware problem sets.')]
-    language_name: Annotated[str | None, Field(description='Short name of the language preset. Mutually exclusive with ``lang_id``.')]
-    lang_id: Annotated[int | str | None, Field(description='Language identifier (numeric or short name). Mutually exclusive with ``language_name``.')]
-    eoln_type: Annotated[int | None, Field(ge=0, description='Line-ending conversion strategy recognised by ejudge.')]
-    is_visible: Annotated[bool | None, Field(description='Set to ``True`` to force the submission to be visible in the UI.')]
-    file: Annotated[bytes | None, Field(description='Source code payload as raw bytes. Mutually exclusive with ``text_form``.')]
-    text_form: Annotated[str | None, Field(description='Source code payload as UTF-8 text. Mutually exclusive with ``file``.')]
+    problem_uuid: Annotated[UUID | None, Field(description='UUID of the problem to target. Mutually exclusive with ``problem_name`` and ``problem``.')] = None
+    problem_name: Annotated[str | None, Field(description='Problem short or internal name. Mutually exclusive with ``problem_uuid`` and ``problem``.')] = None
+    problem: Annotated[ProblemId | None, Field(description='Numeric problem identifier. Mutually exclusive with the other problem selectors.')] = None
+    variant: Annotated[int | None, Field(description='Optional variant identifier for variant-aware problem sets.')] = None
+    language_name: Annotated[str | None, Field(description='Short name of the language preset. Mutually exclusive with ``lang_id``.')] = None
+    lang_id: Annotated[int | str | None, Field(description='Language identifier (numeric or short name). Mutually exclusive with ``language_name``.')] = None
+    eoln_type: Annotated[int | None, Field(ge=0, description='Line-ending conversion strategy recognised by ejudge.')] = None
+    is_visible: Annotated[bool | None, Field(description='Set to ``True`` to force the submission to be visible in the UI.')] = None
+    file: Annotated[bytes | None, Field(description='Source code payload as raw bytes. Mutually exclusive with ``text_form``.')] = None
+    text_form: Annotated[str | None, Field(description='Source code payload as UTF-8 text. Mutually exclusive with ``file``.')] = None
     not_ok_is_cf: Annotated[bool | None, Field(description='Treat any non-OK verdict as ``Check Failed`` when set.')] = None
     rejudge_flag: Annotated[bool | None, Field(description='Submit with the low-priority rejudge queue when ``True``.')] = None
-    ext_user_kind: Annotated[str | None, Field(description='External system identifier type, if ejudge should persist it.')]
-    ext_user: Annotated[str | None, Field(description='Concrete external system identifier for the submitter.')]
+    ext_user_kind: Annotated[str | None, Field(description='External system identifier type, if ejudge should persist it.')] = None
+    ext_user: Annotated[str | None, Field(description='Concrete external system identifier for the submitter.')] = None
     notify_driver: Annotated[int | None, Field(description='Notification driver identifier (see :class:`NotificationTarget`).')] = None
     notify_kind: Annotated[NotificationKind | None, Field(description='Notification queue encoding kind.')] = None
     notify_queue: Annotated[str | None, Field(description='Notification queue identifier payload.')] = None
@@ -129,13 +128,13 @@ class SubmitRunInputRequest(EjudgeBaseModel):
     sender_ssl_flag: Annotated[bool | None, Field(description='Set to ``True`` when the user submitted via HTTPS.')] = None
     prob_id: Annotated[str | int, Field(description='Problem identifier (short name, internal name, or numeric id).')]
     lang_id: Annotated[str | int, Field(description='Language identifier (short name or numeric id).')]
-    eoln_type: Annotated[int | None, Field(ge=0, description='Line-ending conversion strategy recognised by ejudge.')]
-    file: Annotated[bytes | None, Field(description='Source code payload as raw bytes. Mutually exclusive with ``text_form``.')]
-    text_form: Annotated[str | None, Field(description='Source code payload as UTF-8 text. Mutually exclusive with ``file``.')]
-    file_input: Annotated[bytes | None, Field(description='Custom stdin payload as raw bytes. Mutually exclusive with ``text_form_input``.')]
-    text_form_input: Annotated[str | None, Field(description='Custom stdin payload as text. Mutually exclusive with ``file_input``.')]
-    ext_user_kind: Annotated[str | None, Field(description='External system identifier type, if ejudge should persist it.')]
-    ext_user: Annotated[str | None, Field(description='Concrete external system identifier for the submitter.')]
+    eoln_type: Annotated[int | None, Field(ge=0, description='Line-ending conversion strategy recognised by ejudge.')] = None
+    file: Annotated[bytes | None, Field(description='Source code payload as raw bytes. Mutually exclusive with ``text_form``.')] = None
+    text_form: Annotated[str | None, Field(description='Source code payload as UTF-8 text. Mutually exclusive with ``file``.')] = None
+    file_input: Annotated[bytes | None, Field(description='Custom stdin payload as raw bytes. Mutually exclusive with ``text_form_input``.')] = None
+    text_form_input: Annotated[str | None, Field(description='Custom stdin payload as text. Mutually exclusive with ``file_input``.')] = None
+    ext_user_kind: Annotated[str | None, Field(description='External system identifier type, if ejudge should persist it.')] = None
+    ext_user: Annotated[str | None, Field(description='Concrete external system identifier for the submitter.')] = None
     notify_driver: Annotated[int | None, Field(description='Notification driver identifier (see :class:`NotificationTarget`).')] = None
     notify_kind: Annotated[NotificationKind | None, Field(description='Notification queue encoding kind.')] = None
     notify_queue: Annotated[str | None, Field(description='Notification queue identifier payload.')] = None
@@ -172,6 +171,7 @@ class GetUserRequest(EjudgeBaseModel):
     """Query parameters for the privileged ``get-user`` endpoint."""
 
     contest_id: ContestId
+    action: Literal['get-user'] = Field(default='get-user', frozen=True)
     other_user_id: Annotated[UserId | None, Field(description='Numeric user identifier to fetch. Mutually exclusive with ``other_user_login``.')] = None
     other_user_login: Annotated[str | None, Field(description='Login of the user to fetch. Mutually exclusive with ``other_user_id``.')] = None
     global_: Annotated[bool | None, Field(alias='global', description='Set to true to request global (non contest specific) data.')] = None
@@ -196,20 +196,15 @@ class EjudgeError(EjudgeBaseModel):
     message: Annotated[str | None, Field(description='Optional verbose description returned by ejudge.')] = None
 
 
-ResultT = TypeVar('ResultT')
-
-
-class EjudgeReply(GenericModel[ResultT]):
+class EjudgeReply(EjudgeBaseModel):
     """Generic wrapper for ejudge reply envelopes."""
-
-    model_config = ConfigDict(extra='forbid', populate_by_name=True, str_strip_whitespace=True)
 
     ok: bool
     action: str
     server_time: Annotated[int | None, Field(description='Unix timestamp reported by ejudge.')] = None
     reply_id: Annotated[int | None, Field(description='Opaque response identifier used by ejudge.')] = None
     request_id: Annotated[int | None, Field(description='Identifier correlating the reply with the originating request.')] = None
-    result: Annotated[ResultT | None, Field(description='Successful payload returned by ejudge.')] = None
+    result: Annotated[Any | None, Field(description='Successful payload returned by ejudge.')] = None
     error: Annotated[EjudgeError | None, Field(description='Error details when ``ok`` is false.')] = None
 
 
@@ -220,8 +215,10 @@ class SubmitRunResult(EjudgeBaseModel):
     run_uuid: Annotated[UUID | None, Field(description='Optional UUID for the created run (depends on ejudge version).')] = None
 
 
-class SubmitRunReply(EjudgeReply[SubmitRunResult]):
+class SubmitRunReply(EjudgeReply):
     """Reply envelope for ``submit-run``."""
+
+    result: Annotated[SubmitRunResult | None, Field(description='Successful payload returned by ejudge.')] = None
 
 
 class SubmitRunInputResult(EjudgeBaseModel):
@@ -230,8 +227,10 @@ class SubmitRunInputResult(EjudgeBaseModel):
     submit_id: SubmitId
 
 
-class SubmitRunInputReply(EjudgeReply[SubmitRunInputResult]):
+class SubmitRunInputReply(EjudgeReply):
     """Reply envelope for ``submit-run-input``."""
+
+    result: Annotated[SubmitRunInputResult | None, Field(description='Successful payload returned by ejudge.')] = None
 
 
 class SubmitDetails(EjudgeBaseModel):
@@ -252,8 +251,8 @@ class SubmitDetails(EjudgeBaseModel):
     test_checker_output: Annotated[str | None, Field(description='Checker diagnostic output, if any.')] = None
     time: Milliseconds | None = Field(default=None, description='CPU time spent processing the submission.')
     real_time: Milliseconds | None = Field(default=None, description='Wall clock time spent processing the submission.')
-    exit_code: Annotated[int | None, Field(description='Process exit code reported by ejudge.')]
-    term_signal: Annotated[int | None, Field(description='Termination signal (POSIX) if the process was killed.')]
+    exit_code: Annotated[int | None, Field(description='Process exit code reported by ejudge.')] = None
+    term_signal: Annotated[int | None, Field(description='Termination signal (POSIX) if the process was killed.')] = None
     max_memory_used: BytesCount | None = Field(default=None, description='Maximum virtual memory usage reported by ejudge.')
     max_rss: BytesCount | None = Field(default=None, description='Maximum resident memory usage reported by ejudge.')
     input: Annotated[str | None, Field(description='Captured stdin used for the submission (submit-run-input only).')] = None
@@ -261,8 +260,10 @@ class SubmitDetails(EjudgeBaseModel):
     error: Annotated[str | None, Field(description='Captured stderr produced by the submission.')] = None
 
 
-class GetSubmitReply(EjudgeReply[SubmitDetails]):
+class GetSubmitReply(EjudgeReply):
     """Reply envelope for ``get-submit``."""
+
+    result: Annotated[SubmitDetails | None, Field(description='Successful payload returned by ejudge.')] = None
 
 
 class UserContestState(EjudgeBaseModel):
@@ -342,8 +343,10 @@ class UserProfile(EjudgeBaseModel):
     infos: Annotated[list[UserInfo] | None, Field(description='Contest-specific profile fields.')] = None
 
 
-class GetUserReply(EjudgeReply[UserProfile]):
+class GetUserReply(EjudgeReply):
     """Reply envelope for ``get-user``."""
+
+    result: Annotated[UserProfile | None, Field(description='Successful payload returned by ejudge.')] = None
 
 
 # Friendly aliases exported at package level.

--- a/backend/tests/ejudge/test_client.py
+++ b/backend/tests/ejudge/test_client.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import asyncio
+
+import httpx
+import pytest
+
+from backend.ejudge import (
+    EjudgeClient,
+    EjudgeClientError,
+    EjudgeReplyError,
+    GetSubmitRequest,
+    GetUserRequest,
+    SubmitRunInputRequest,
+    SubmitRunRequest,
+    create_mock_transport,
+    make_get_submit_reply,
+    make_get_user_reply,
+    make_submit_details,
+    make_submit_run_input_reply,
+    make_submit_run_reply,
+)
+
+
+def test_submit_run_text_payload() -> None:
+    async def scenario() -> None:
+        reply = make_submit_run_reply(run_id=42)
+        transport, calls = create_mock_transport(submit_run=reply)
+
+        async with EjudgeClient('https://ejudge.local/cgi-bin/master', 'token', transport=transport) as client:
+            request = SubmitRunRequest(
+                contest_id=7,
+                problem=5,
+                lang_id='py3',
+                text_form='print("hello")',
+                is_visible=True,
+            )
+            result = await client.submit_run(request)
+
+        assert result == reply
+        assert len(calls) == 1
+        call = calls[0]
+        assert call.headers['Authorization'] == 'Bearer AQAAtoken'
+        assert call.url.params['json'] == '1'
+        body = httpx.QueryParams(call.content.decode())
+        assert body['contest_id'] == '7'
+        assert body['lang_id'] == 'py3'
+        assert body['problem'] == '5'
+        assert body['is_visible'] == '1'
+        assert body['text_form'] == 'print("hello")'
+
+    asyncio.run(scenario())
+
+
+def test_submit_run_binary_payload() -> None:
+    async def scenario() -> None:
+        reply = make_submit_run_reply(run_id=101)
+        transport, calls = create_mock_transport(submit_run=reply)
+
+        async with EjudgeClient('https://ejudge.local/cgi-bin/master', 'secrettoken', transport=transport) as client:
+            request = SubmitRunRequest(
+                contest_id=2,
+                problem=3,
+                language_name='cpp',
+                file=b'int main(){}',
+            )
+            await client.submit_run(request)
+
+        call = calls[0]
+        assert 'multipart/form-data' in call.headers['content-type']
+        assert b'int main(){}' in call.content
+
+    asyncio.run(scenario())
+
+
+def test_submit_run_input_text_payload() -> None:
+    async def scenario() -> None:
+        reply = make_submit_run_input_reply(submit_id=314)
+        transport, calls = create_mock_transport(submit_run_input=reply)
+
+        async with EjudgeClient('https://ejudge.local/cgi-bin/master', 'abc', transport=transport) as client:
+            request = SubmitRunInputRequest(
+                contest_id=9,
+                prob_id='A',
+                lang_id='py3',
+                text_form='print("42")',
+                text_form_input='1 2 3',
+            )
+            result = await client.submit_run_input(request)
+
+        assert result == reply
+        call = calls[0]
+        body = httpx.QueryParams(call.content.decode())
+        assert body['contest_id'] == '9'
+        assert body['prob_id'] == 'A'
+        assert body['lang_id'] == 'py3'
+        assert body['text_form'] == 'print("42")'
+        assert body['text_form_input'] == '1 2 3'
+
+    asyncio.run(scenario())
+
+
+def test_get_submit_roundtrip() -> None:
+    async def scenario() -> None:
+        details = make_submit_details(submit_id=555, status=1, status_str='WA')
+        reply = make_get_submit_reply(details)
+        transport, calls = create_mock_transport(get_submit=reply)
+
+        async with EjudgeClient('https://ejudge.local/cgi-bin/master', 'zzz', transport=transport) as client:
+            request = GetSubmitRequest(contest_id=1, submit_id=555)
+            result = await client.get_submit(request)
+
+        assert result == reply
+        call = calls[0]
+        assert call.url.params['contest_id'] == '1'
+        assert call.url.params['submit_id'] == '555'
+
+    asyncio.run(scenario())
+
+
+def test_get_user_roundtrip() -> None:
+    async def scenario() -> None:
+        reply = make_get_user_reply()
+        transport, calls = create_mock_transport(get_user=reply)
+
+        async with EjudgeClient('https://ejudge.local/cgi-bin/master', 'ttt', transport=transport) as client:
+            request = GetUserRequest(contest_id=4, other_user_login='john')
+            result = await client.get_user(request)
+
+        assert result == reply
+        call = calls[0]
+        assert call.url.params['other_user_login'] == 'john'
+        assert call.url.params['contest_id'] == '4'
+
+    asyncio.run(scenario())
+
+
+def test_error_reply_raises() -> None:
+    async def scenario() -> None:
+        bad_reply = make_submit_run_reply(run_id=1).model_copy(update={'ok': False})
+        transport, _ = create_mock_transport(submit_run=bad_reply)
+
+        async with EjudgeClient('https://ejudge.local/cgi-bin/master', 'token', transport=transport) as client:
+            request = SubmitRunRequest(contest_id=1, problem=1, lang_id='py', text_form='pass')
+            with pytest.raises(EjudgeReplyError):
+                await client.submit_run(request)
+
+    asyncio.run(scenario())
+
+
+def test_http_error_raises_client_error() -> None:
+    async def scenario() -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(500, json={'detail': 'boom'})
+
+        transport = httpx.MockTransport(handler)
+
+        async with EjudgeClient('https://ejudge.local/cgi-bin/master', 'token', transport=transport) as client:
+            request = GetSubmitRequest(contest_id=1, submit_id=10)
+            with pytest.raises(EjudgeClientError):
+                await client.get_submit(request)
+
+    asyncio.run(scenario())


### PR DESCRIPTION
## Summary
- add an async httpx-powered client that wraps the ejudge submit and metadata endpoints
- provide reusable mock transport helpers to simulate ejudge responses in tests
- cover the new client with pytest exercising happy and failure paths and document the integration in ARCHITECTURE.md

## Testing
- pytest tests/ejudge/test_client.py

------
https://chatgpt.com/codex/tasks/task_e_68d7aa0d95048326abc813650d6b0c65