### PR TITLE
Add synchronous ejudge REPL helper

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,5 @@ DATABASE_URL=sqlite+aiosqlite:///./ejapp.db
 FRONTEND_ORIGIN=http://localhost:5173
 GOOGLE_CLIENT_ID=<your-google-client-id>       # (optional, for real Google OAuth)
 GOOGLE_CLIENT_SECRET=<your-google-client-secret> # (optional)
+EJUDGE_ORIGIN=https://leaders.tech/
+EJUDGE_TOKEN=asdfasdfasdfasdfasdfasdfasdf

--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,11 @@ run-frontend: ## Vite: Run frontend dev server with auto-reload
 	@echo "--- Starting frontend server at http://localhost:5173 ---"
 	(cd $(FRONTEND_DIR) && npm run dev)
 
+.PHONY: repl
+repl: ## Open an interactive ejudge REPL with helpful shortcuts
+	@echo "--- Launching ejudge REPL (requires EJUDGE_ORIGIN and EJUDGE_TOKEN) ---"
+	PYTHONPATH=. $(PYTHON) -m backend.ejudge.repl
+
 # --- Code Quality ---
 .PHONY: format
 format: format-backend format-frontend ## 💅 Format all code (Python & Frontend)

--- a/README.md
+++ b/README.md
@@ -84,6 +84,22 @@
   ```
   Optional knobs `EJUDGE_CONTEST_ID` and `EJUDGE_RUN_FILTER` let you target a different contest or subset of runs without editing the suite.
 
+## Exploring the ejudge API interactively
+When you need to inspect ejudge endpoints manually, launch the synchronous REPL helper:
+
+```bash
+EJUDGE_ORIGIN="https://leaders.tech" EJUDGE_TOKEN="<token>" make repl
+```
+
+The session wires up a shared HTTP/2 client and exposes handy names:
+
+- `ej` — the full synchronous façade (typed helpers like `ej.submit_run(...)`).
+- `ej_client` — shortcuts for `/master` endpoints, e.g. `pp(ej_client.list_runs_json(contest_id=302, first_run=0, last_run=5))`.
+- `pp` — a `pprint` partial with a generous width for large JSON payloads.
+- `SubmitRunRequest`, `GetSubmitRequest`, etc. — Pydantic request models ready for use.
+
+Type `Ctrl+D` (EOF) to exit the REPL; resources are closed automatically.
+
 ## Database Migrations
 - Create a new migration:
   ```bash

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -23,6 +23,8 @@ class Settings:
     allowed_origins: list[str] = field(init=False)
     e2e: bool = field(default_factory=lambda: os.getenv('E2E') == '1')
     private_path_prefixes: tuple[str, ...] = ('/private',)
+    ejudge_origin: str = field(default_factory=lambda: os.getenv('EJUDGE_ORIGIN', None))
+    ejudge_token: str = field(default_factory=lambda: os.getenv('EJUDGE_TOKEN', None))
 
     _backend_dir: Path = field(init=False, repr=False)
 

--- a/backend/ejudge/__init__.py
+++ b/backend/ejudge/__init__.py
@@ -25,6 +25,7 @@ from .models import (
     SubmitRunReply,
     SubmitRunRequest,
 )
+from .repl import EjudgeSyncClient, start_repl
 
 __all__ = [
     'EjudgeClient',
@@ -32,6 +33,7 @@ __all__ = [
     'EjudgeError',
     'EjudgeReply',
     'EjudgeReplyError',
+    'EjudgeSyncClient',
     'GetSubmitReply',
     'GetSubmitRequest',
     'GetUserReply',
@@ -50,4 +52,5 @@ __all__ = [
     'make_submit_details',
     'make_submit_run_input_reply',
     'make_submit_run_reply',
+    'start_repl',
 ]

--- a/backend/ejudge/repl.py
+++ b/backend/ejudge/repl.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import asyncio
 import code
-import os
 from collections.abc import Mapping
 from functools import partial
 from pprint import pprint
@@ -12,6 +11,8 @@ from textwrap import dedent
 from typing import Any
 
 import httpx
+
+from backend.app.config import settings
 
 from .client import EjudgeClient
 from .models import (
@@ -24,6 +25,8 @@ from .models import (
     SubmitRunReply,
     SubmitRunRequest,
 )
+
+print(f'{settings.ejudge_origin=}')
 
 
 class _SyncNamespace:
@@ -144,8 +147,8 @@ def _make_banner(base_url: str) -> str:
 
 
 def start_repl(*, base_url: str | None = None, api_token: str | None = None) -> None:
-    base_url = base_url or os.environ.get('EJUDGE_ORIGIN')
-    api_token = api_token or os.environ.get('EJUDGE_TOKEN')
+    base_url = settings.ejudge_origin
+    api_token = settings.ejudge_token
 
     if not base_url or not api_token:
         msg = 'Set EJUDGE_ORIGIN and EJUDGE_TOKEN environment variables before launching the REPL.'
@@ -171,6 +174,5 @@ def main() -> int:
 
 if __name__ == '__main__':
     raise SystemExit(main())
-
 
 __all__ = ['EjudgeSyncClient', 'start_repl']

--- a/backend/ejudge/repl.py
+++ b/backend/ejudge/repl.py
@@ -1,0 +1,176 @@
+"""Interactive helpers for exploring the ejudge HTTP API from a Python shell."""
+
+from __future__ import annotations
+
+import asyncio
+import code
+import os
+from collections.abc import Mapping
+from functools import partial
+from pprint import pprint
+from textwrap import dedent
+from typing import Any
+
+import httpx
+
+from .client import EjudgeClient
+from .models import (
+    GetSubmitReply,
+    GetSubmitRequest,
+    GetUserReply,
+    GetUserRequest,
+    SubmitRunInputReply,
+    SubmitRunInputRequest,
+    SubmitRunReply,
+    SubmitRunRequest,
+)
+
+
+class _SyncNamespace:
+    """Expose async ejudge operations as synchronous callables."""
+
+    def __init__(self, owner: EjudgeSyncClient, operations: Mapping[str, Any]):
+        self._owner = owner
+        for spec in operations.values():
+            setattr(self, spec.name, self._wrap(spec))
+
+    def _wrap(self, spec: Any) -> Any:
+        def call(**kwargs: Any) -> Any:
+            return self._owner._run(self._owner._client._call_operation(spec, kwargs))
+
+        call.__name__ = spec.name
+        if spec.description:
+            call.__doc__ = spec.description
+        return call
+
+
+class EjudgeSyncClient:
+    """Synchronous façade around :class:`~backend.ejudge.client.EjudgeClient`."""
+
+    def __init__(
+        self,
+        base_url: str,
+        api_token: str,
+        *,
+        timeout: float | httpx.Timeout | None = 10.0,
+        transport: httpx.BaseTransport | None = None,
+        http2: bool = True,
+    ) -> None:
+        self._runner = asyncio.Runner()
+        self._http_client = httpx.AsyncClient(
+            base_url=base_url,
+            timeout=timeout,
+            transport=transport,
+            http2=http2,
+        )
+        self._client = EjudgeClient(base_url, api_token, http_client=self._http_client)
+        self._closed = False
+
+        operations = self._client._operations
+        self.client = _SyncNamespace(self, operations['client'])
+        self.master = _SyncNamespace(self, operations['master'])
+
+    def __enter__(self) -> EjudgeSyncClient:
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.close()
+
+    def close(self) -> None:
+        if self._closed:
+            return
+
+        self._runner.run(self._client.aclose())
+        self._runner.run(self._http_client.aclose())
+        self._runner.close()
+        self._closed = True
+
+    def _ensure_open(self) -> None:
+        if self._closed:
+            msg = 'EjudgeSyncClient is closed.'
+            raise RuntimeError(msg)
+
+    def _run(self, awaitable: Any) -> Any:
+        self._ensure_open()
+        return self._runner.run(awaitable)
+
+    # -- Typed convenience wrappers -------------------------------------
+
+    def submit_run(self, request: SubmitRunRequest) -> SubmitRunReply:
+        return self._run(self._client.submit_run(request))
+
+    def submit_run_input(self, request: SubmitRunInputRequest) -> SubmitRunInputReply:
+        return self._run(self._client.submit_run_input(request))
+
+    def get_submit(self, request: GetSubmitRequest) -> GetSubmitReply:
+        return self._run(self._client.get_submit(request))
+
+    def get_user(self, request: GetUserRequest) -> GetUserReply:
+        return self._run(self._client.get_user(request))
+
+
+def _make_namespace(client: EjudgeSyncClient) -> dict[str, Any]:
+    pretty = partial(pprint, width=160, sort_dicts=False)
+    return {
+        'ej': client,
+        'EjudgeSyncClient': EjudgeSyncClient,
+        'ej_client': client.master,
+        'ej_master': client.master,
+        'ej_service': client.client,
+        'pp': pretty,
+        'pretty': pretty,
+        'pprint': pprint,
+        'SubmitRunRequest': SubmitRunRequest,
+        'SubmitRunInputRequest': SubmitRunInputRequest,
+        'GetSubmitRequest': GetSubmitRequest,
+        'GetUserRequest': GetUserRequest,
+    }
+
+
+def _make_banner(base_url: str) -> str:
+    return dedent(
+        f"""
+        ejudge REPL connected to {base_url}
+
+        Helpful names:
+          • ej          - synchronous facade (EjudgeSyncClient)
+          • ej_client   - /master namespace shortcuts (e.g. ej_client.list_runs_json(...))
+          • pp          - pprint with sensible defaults
+          • SubmitRunRequest, GetSubmitRequest, ... - typed payload helpers
+
+        Press Ctrl-D (EOF) to exit the session.
+        """
+    ).strip()
+
+
+def start_repl(*, base_url: str | None = None, api_token: str | None = None) -> None:
+    base_url = base_url or os.environ.get('EJUDGE_ORIGIN')
+    api_token = api_token or os.environ.get('EJUDGE_TOKEN')
+
+    if not base_url or not api_token:
+        msg = 'Set EJUDGE_ORIGIN and EJUDGE_TOKEN environment variables before launching the REPL.'
+        raise RuntimeError(msg)
+
+    with EjudgeSyncClient(base_url, api_token) as client:
+        banner = _make_banner(base_url)
+        namespace = _make_namespace(client)
+        code.interact(banner=banner, local=namespace)
+
+
+def main() -> int:
+    try:
+        start_repl()
+    except RuntimeError as exc:
+        print(exc)
+        return 1
+    except KeyboardInterrupt:
+        print()
+        return 130
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())
+
+
+__all__ = ['EjudgeSyncClient', 'start_repl']

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "PyJWT",
     "alembic",
     "pytest",
-    "httpx",
+    "httpx[http2]",
     "greenlet",
     "xmltodict",
 ]

--- a/backend/tests/ejudge/test_integration.py
+++ b/backend/tests/ejudge/test_integration.py
@@ -7,13 +7,14 @@ from typing import Any, TypedDict
 
 import pytest
 
+from backend.app.config import settings
 from backend.ejudge import EjudgeClient
 
 # -- Environment helpers -------------------------------------------------
 # Pull credentials for the real ejudge instance from the environment. The
 # integration suite is skipped entirely when they are not provided.
-EJUDGE_ORIGIN = os.getenv('EJUDGE_ORIGIN')
-EJUDGE_TOKEN = os.getenv('EJUDGE_TOKEN')
+EJUDGE_ORIGIN = settings.ejudge_origin
+EJUDGE_TOKEN = settings.ejudge_token
 
 # Allow customisation of the contest identifier and filtering behaviour
 # without touching the test code. Defaults mirror the shared sandbox.

--- a/backend/tests/ejudge/test_repl.py
+++ b/backend/tests/ejudge/test_repl.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import httpx
+
+from backend.ejudge import (
+    EjudgeSyncClient,
+    SubmitRunReply,
+    SubmitRunRequest,
+    create_mock_transport,
+    make_submit_run_reply,
+)
+
+
+def test_master_namespace_exposes_sync_operations() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == 'GET'
+        assert request.url.path == '/ej/api/v1/master/list-runs-json'
+        assert request.headers['Authorization'] == 'Bearer AQAAtoken'
+        assert request.url.params['contest_id'] == '302'
+        assert request.url.params['first_run'] == '0'
+        assert request.url.params['last_run'] == '5'
+        payload = {
+            'ok': True,
+            'result': {
+                'runs': [],
+                'first_run': 0,
+                'last_run': 5,
+            },
+        }
+        return httpx.Response(200, json=payload)
+
+    transport = httpx.MockTransport(handler)
+
+    with EjudgeSyncClient('https://ejudge.local', 'token', transport=transport, http2=False) as client:
+        payload = client.master.list_runs_json(contest_id=302, first_run=0, last_run=5)
+
+    assert payload['ok'] is True
+    assert payload['result']['runs'] == []
+
+
+def test_typed_wrappers_run_synchronously() -> None:
+    reply = make_submit_run_reply(run_id=77)
+    transport, calls = create_mock_transport(submit_run=reply)
+
+    with EjudgeSyncClient('https://ejudge.local', 'secrettoken', transport=transport, http2=False) as client:
+        request = SubmitRunRequest(contest_id=9, problem=1, lang_id='py3', text_form='print(42)')
+        result = client.submit_run(request)
+
+    assert isinstance(result, SubmitRunReply)
+    assert result.result.run_id == 77
+    assert len(calls) == 1
+    call = calls[0]
+    assert call.headers['Authorization'] == 'Bearer AQAAsecrettoken'
+
+
+def test_close_is_idempotent() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, text='<ok/>')
+
+    client = EjudgeSyncClient('https://ejudge.local', 'token', transport=httpx.MockTransport(handler), http2=False)
+
+    try:
+        client.master.raw_report(contest_id=1, run_id=2)
+    finally:
+        client.close()
+        client.close()


### PR DESCRIPTION
## Summary
- add a synchronous `EjudgeSyncClient` façade and REPL bootstrap module for exploring ejudge endpoints
- expose a `make repl` target and document the workflow in the README
- cover the new client with unit tests for typed wrappers, namespace calls, and lifecycle management

## Testing
- make test-backend

------
https://chatgpt.com/codex/tasks/task_e_68eb5dba82a88326803574719b5cc08f