### PR TITLE
Add ejudge contest reports UI and API

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -10,6 +10,7 @@ from jwt import PyJWTError
 
 from backend.app import auth
 from backend.app.config import settings
+from backend.app.contest_reports import router as contest_reports_router
 from backend.app.database import engine
 from backend.app.items import private_router, router as items_router
 from backend.db import Base
@@ -66,6 +67,7 @@ def create_app() -> FastAPI:
     application.include_router(auth.router)
     application.include_router(items_router)
     application.include_router(private_router)
+    application.include_router(contest_reports_router)
     return application
 
 

--- a/backend/app/contest_reports.py
+++ b/backend/app/contest_reports.py
@@ -1,0 +1,267 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime
+from typing import Annotated, Any
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend.app.config import settings
+from backend.app.deps import SessionDep, TokenDep, get_current_user_id
+from backend.app.schemas import (
+    ContestCell,
+    ContestConfigPayload,
+    ContestProblem,
+    ContestReport,
+    ContestReportsResponse,
+    ContestRow,
+    ContestRunSummary,
+)
+from backend.db import ContestReportConfig
+from backend.ejudge import EjudgeClient, EjudgeClientError
+
+router = APIRouter(prefix='/private', tags=['private'])
+
+_HIGHLIGHT_PRIORITY = {'OK': 0, 'AC': 1, 'PR': 2, 'SM': 3}
+_HIGHLIGHT_STATUSES = set(_HIGHLIGHT_PRIORITY)
+
+
+async def _get_or_create_config(session: AsyncSession, user_id: int) -> ContestReportConfig:
+    result = await session.execute(select(ContestReportConfig).where(ContestReportConfig.user_id == user_id))
+    config = result.scalars().first()
+    if config is None:
+        config = ContestReportConfig(user_id=user_id, contest_ids='')
+        session.add(config)
+        await session.commit()
+        await session.refresh(config)
+    return config
+
+
+def _parse_contest_ids(raw: str) -> list[int]:
+    if not raw:
+        return []
+    ids: set[int] = set()
+    for part in raw.split(','):
+        item = part.strip()
+        if not item:
+            continue
+        try:
+            value = int(item)
+        except ValueError:
+            continue
+        if value > 0:
+            ids.add(value)
+    return sorted(ids)
+
+
+def _serialize_contest_ids(values: list[int]) -> str:
+    deduped = sorted({value for value in values if value > 0})
+    return ','.join(str(value) for value in deduped)
+
+
+async def get_ejudge_client() -> AsyncIterator[EjudgeClient]:
+    if not settings.ejudge_origin or not settings.ejudge_token:
+        raise HTTPException(status_code=503, detail='Ejudge integration is not configured')
+
+    origin = settings.ejudge_origin.rstrip('/')
+    async with EjudgeClient(origin, settings.ejudge_token) as client:
+        yield client
+
+
+EjudgeClientDep = Annotated[EjudgeClient, Depends(get_ejudge_client)]
+
+
+def _extract_submission_time(run: dict[str, Any]) -> datetime | None:
+    candidates: list[tuple[str, float]] = [
+        ('last_change_us', 1_000_000),
+        ('time_us', 1_000_000),
+        ('time_ms', 1_000),
+        ('time', 1),
+    ]
+    for key, divisor in candidates:
+        value = run.get(key)
+        if isinstance(value, int | float):
+            seconds = value / divisor
+            try:
+                return datetime.fromtimestamp(seconds, tz=UTC)
+            except (OverflowError, OSError):
+                continue
+    return None
+
+
+def _build_run_summary(run: dict[str, Any]) -> ContestRunSummary:
+    status = str(run.get('status_str') or '').strip().upper()
+    language = run.get('lang_name') or run.get('language')
+    if language is None and run.get('lang_id') is not None:
+        language = str(run['lang_id'])
+    submitted_at = _extract_submission_time(run)
+    return ContestRunSummary(
+        run_id=int(run['run_id']),
+        status=status,
+        language=language,
+        submitted_at=submitted_at,
+    )
+
+
+def _is_better_run(candidate: ContestRunSummary, current: ContestRunSummary) -> bool:
+    cand_priority = _HIGHLIGHT_PRIORITY.get(candidate.status, float('inf'))
+    current_priority = _HIGHLIGHT_PRIORITY.get(current.status, float('inf'))
+    if cand_priority != current_priority:
+        return cand_priority < current_priority
+
+    cand_time = candidate.submitted_at
+    current_time = current.submitted_at
+    if cand_time and current_time:
+        if cand_time != current_time:
+            return cand_time < current_time
+    elif cand_time and not current_time:
+        return True
+    elif current_time and not cand_time:
+        return False
+
+    return candidate.run_id < current.run_id
+
+
+def _build_report(
+    contest_id: int,
+    contest_payload: dict[str, Any],
+    problems_payload: list[dict[str, Any]],
+    runs_payload: list[dict[str, Any]],
+) -> ContestReport:
+    contest_name = contest_payload.get('name') or contest_payload.get('name_en') or f'Contest {contest_id}'
+
+    problems: list[ContestProblem] = []
+    for problem in problems_payload:
+        try:
+            pid = int(problem['id'])
+        except (KeyError, TypeError, ValueError):
+            continue
+        problems.append(
+            ContestProblem(
+                id=pid,
+                short_name=str(problem.get('short_name') or pid),
+                long_name=problem.get('long_name'),
+            )
+        )
+    problems.sort(key=lambda item: (item.short_name, item.id))
+
+    rows: dict[int, dict[str, Any]] = {}
+    cells_by_user: dict[int, dict[int, ContestRunSummary]] = defaultdict(dict)
+
+    for run in runs_payload:
+        try:
+            user_id = int(run['user_id'])
+            problem_id = int(run['prob_id'])
+            int(run['run_id'])
+        except (KeyError, TypeError, ValueError):
+            continue
+
+        rows.setdefault(
+            user_id,
+            {
+                'user_id': user_id,
+                'user_login': str(run.get('user_login') or f'user-{user_id}'),
+                'user_name': run.get('user_name'),
+            },
+        )
+        status = str(run.get('status_str') or '').strip().upper()
+        if status not in _HIGHLIGHT_STATUSES:
+            continue
+
+        summary = _build_run_summary(run)
+        current = cells_by_user[user_id].get(problem_id)
+        if current is None or _is_better_run(summary, current):
+            cells_by_user[user_id][problem_id] = summary
+
+    contest_rows: list[ContestRow] = []
+    for user_id, row_payload in rows.items():
+        ordered_cells: list[ContestCell] = []
+        for problem in problems:
+            ordered_cells.append(
+                ContestCell(
+                    problem_id=problem.id,
+                    best_run=cells_by_user[user_id].get(problem.id),
+                )
+            )
+        contest_rows.append(
+            ContestRow(
+                user_id=user_id,
+                user_login=row_payload['user_login'],
+                user_name=row_payload.get('user_name'),
+                cells=ordered_cells,
+            )
+        )
+
+    contest_rows.sort(key=lambda row: (row.user_name or row.user_login, row.user_id))
+
+    return ContestReport(
+        contest_id=contest_id,
+        contest_name=str(contest_name),
+        problems=problems,
+        rows=contest_rows,
+    )
+
+
+@router.get('/contest-config', response_model=ContestConfigPayload)
+async def get_contest_config(session: SessionDep, token: TokenDep) -> ContestConfigPayload:
+    user_id = await get_current_user_id(token, session)
+    config = await _get_or_create_config(session, user_id)
+    ids = _parse_contest_ids(config.contest_ids)
+    return ContestConfigPayload(contest_ids=ids)
+
+
+@router.put('/contest-config', response_model=ContestConfigPayload)
+async def update_contest_config(
+    payload: ContestConfigPayload,
+    session: SessionDep,
+    token: TokenDep,
+) -> ContestConfigPayload:
+    user_id = await get_current_user_id(token, session)
+    config = await _get_or_create_config(session, user_id)
+    serialised = _serialize_contest_ids(payload.contest_ids)
+    config.contest_ids = serialised
+    await session.commit()
+    ids = _parse_contest_ids(config.contest_ids)
+    return ContestConfigPayload(contest_ids=ids)
+
+
+@router.get('/contest-reports', response_model=ContestReportsResponse)
+async def get_contest_reports(
+    session: SessionDep,
+    token: TokenDep,
+    ejudge_client: EjudgeClientDep,
+) -> ContestReportsResponse:
+    user_id = await get_current_user_id(token, session)
+    config = await _get_or_create_config(session, user_id)
+    contest_ids = _parse_contest_ids(config.contest_ids)
+    if not contest_ids:
+        return ContestReportsResponse(contests=[])
+
+    reports: list[ContestReport] = []
+    for contest_id in contest_ids:
+        try:
+            contest_payload = await ejudge_client.master.contest_status_json(contest_id=contest_id)
+            if not contest_payload.get('ok'):
+                raise HTTPException(status_code=502, detail=f'Failed to fetch contest {contest_id} metadata')
+            contest_result = contest_payload.get('result') or {}
+            contest_info = contest_result.get('contest') or {}
+            problems_payload = contest_result.get('problems') or []
+
+            runs_payload = await ejudge_client.master.list_runs_json(contest_id=contest_id, first_run=0)
+            if not runs_payload.get('ok'):
+                raise HTTPException(status_code=502, detail=f'Failed to fetch contest {contest_id} runs')
+            runs_result = runs_payload.get('result') or {}
+            runs = runs_result.get('runs') or []
+        except EjudgeClientError as exc:
+            raise HTTPException(status_code=502, detail=f'Error talking to ejudge for contest {contest_id}') from exc
+
+        report = _build_report(contest_id, contest_info, list(problems_payload), list(runs))
+        reports.append(report)
+
+    return ContestReportsResponse(contests=reports)
+
+
+__all__ = ['get_ejudge_client', 'router']

--- a/backend/app/contest_reports.py
+++ b/backend/app/contest_reports.py
@@ -36,19 +36,12 @@ async def _ensure_config_table() -> None:
         await conn.run_sync(ContestReportConfig.__table__.create, checkfirst=True)
 
 
-def _is_missing_table_error(exc: OperationalError) -> bool:
-    message = str(exc).lower()
-    return 'no such table' in message and 'contest_report_configs' in message
-
-
 async def _get_or_create_config(session: AsyncSession, user_id: int) -> ContestReportConfig:
+    await _ensure_config_table()
     try:
         result = await session.execute(select(ContestReportConfig).where(ContestReportConfig.user_id == user_id))
-    except OperationalError as exc:
-        if not _is_missing_table_error(exc):
-            raise
-        await _ensure_config_table()
-        result = await session.execute(select(ContestReportConfig).where(ContestReportConfig.user_id == user_id))
+    except OperationalError as exc:  # pragma: no cover - propagated to the client
+        raise HTTPException(status_code=500, detail='Database error while reading contest config') from exc
     config = result.scalars().first()
     if config is None:
         config = ContestReportConfig(user_id=user_id, contest_ids='')

--- a/backend/app/contest_reports.py
+++ b/backend/app/contest_reports.py
@@ -7,9 +7,11 @@ from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy import select
+from sqlalchemy.exc import OperationalError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend.app.config import settings
+from backend.app.database import engine
 from backend.app.deps import SessionDep, TokenDep, get_current_user_id
 from backend.app.schemas import (
     ContestCell,
@@ -29,8 +31,24 @@ _HIGHLIGHT_PRIORITY = {'OK': 0, 'AC': 1, 'PR': 2, 'SM': 3}
 _HIGHLIGHT_STATUSES = set(_HIGHLIGHT_PRIORITY)
 
 
+async def _ensure_config_table() -> None:
+    async with engine.begin() as conn:
+        await conn.run_sync(ContestReportConfig.__table__.create, checkfirst=True)
+
+
+def _is_missing_table_error(exc: OperationalError) -> bool:
+    message = str(exc).lower()
+    return 'no such table' in message and 'contest_report_configs' in message
+
+
 async def _get_or_create_config(session: AsyncSession, user_id: int) -> ContestReportConfig:
-    result = await session.execute(select(ContestReportConfig).where(ContestReportConfig.user_id == user_id))
+    try:
+        result = await session.execute(select(ContestReportConfig).where(ContestReportConfig.user_id == user_id))
+    except OperationalError as exc:
+        if not _is_missing_table_error(exc):
+            raise
+        await _ensure_config_table()
+        result = await session.execute(select(ContestReportConfig).where(ContestReportConfig.user_id == user_id))
     config = result.scalars().first()
     if config is None:
         config = ContestReportConfig(user_id=user_id, contest_ids='')

--- a/backend/app/deps.py
+++ b/backend/app/deps.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import Depends, HTTPException
+from jwt import PyJWTError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend.app.auth import decode_token, oauth2_scheme
+from backend.app.database import get_session, get_user_by_email
+
+SessionDep = Annotated[AsyncSession, Depends(get_session)]
+TokenDep = Annotated[str, Depends(oauth2_scheme)]
+
+
+async def get_current_user_id(token: TokenDep, session: SessionDep) -> int:
+    try:
+        payload = decode_token(token)
+    except PyJWTError as exc:  # pragma: no cover - propagated via HTTPException below
+        raise HTTPException(status_code=401, detail='Not authenticated') from exc
+
+    email = payload.get('sub')
+    if not email:
+        raise HTTPException(status_code=401, detail='Invalid token payload')
+
+    user = await get_user_by_email(session, email)
+    if not user:
+        raise HTTPException(status_code=401, detail='User not found')
+    return user.id
+
+
+__all__ = ['SessionDep', 'TokenDep', 'get_current_user_id']

--- a/backend/app/items.py
+++ b/backend/app/items.py
@@ -1,21 +1,14 @@
 from __future__ import annotations
 
-from typing import Annotated
-
-from fastapi import APIRouter, Depends, HTTPException
-from jwt import PyJWTError
+from fastapi import APIRouter
 from sqlalchemy import select
-from sqlalchemy.ext.asyncio import AsyncSession
 
-from backend.app.auth import decode_token, oauth2_scheme
-from backend.app.database import get_session, get_user_by_email
+from backend.app.deps import SessionDep, TokenDep, get_current_user_id
 from backend.app.schemas import ItemCreate, ItemOut, ItemRead
 from backend.db import Item
 
 router = APIRouter(tags=['items'])
 private_router = APIRouter(prefix='/private', tags=['private'])
-SessionDep = Annotated[AsyncSession, Depends(get_session)]
-TokenDep = Annotated[str, Depends(oauth2_scheme)]
 
 
 @router.get('/healthz', include_in_schema=False)
@@ -23,28 +16,12 @@ async def healthz() -> dict[str, str]:
     return {'status': 'ok'}
 
 
-async def _get_user_from_token(token: str, session: AsyncSession) -> int:
-    try:
-        payload = decode_token(token)
-    except PyJWTError as exc:
-        raise HTTPException(status_code=401, detail='Not authenticated') from exc
-
-    email = payload.get('sub')
-    if not email:
-        raise HTTPException(status_code=401, detail='Invalid token payload')
-
-    user = await get_user_by_email(session, email)
-    if not user:
-        raise HTTPException(status_code=401, detail='User not found')
-    return user.id
-
-
 @router.get('/items', response_model=list[ItemRead])
 async def read_items(
     session: SessionDep,
     token: TokenDep,
 ) -> list[ItemRead]:
-    user_id = await _get_user_from_token(token, session)
+    user_id = await get_current_user_id(token, session)
     result = await session.execute(select(Item.title).where(Item.owner_id == user_id))
     return [ItemRead(title=title) for title in result.scalars().all()]
 
@@ -55,7 +32,7 @@ async def create_item(
     session: SessionDep,
     token: TokenDep,
 ) -> ItemOut:
-    user_id = await _get_user_from_token(token, session)
+    user_id = await get_current_user_id(token, session)
 
     item = Item(title=item_in.title, owner_id=user_id)
     session.add(item)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
-from pydantic import BaseModel
+from datetime import datetime
+from typing import Annotated
+
+from pydantic import BaseModel, Field
 
 
 class Token(BaseModel):
@@ -28,3 +31,43 @@ class ItemRead(BaseModel):
 
 class ItemOut(ItemRead):
     id: int
+
+
+class ContestConfigPayload(BaseModel):
+    contest_ids: list[Annotated[int, Field(gt=0)]]
+
+
+class ContestProblem(BaseModel):
+    id: int
+    short_name: str
+    long_name: str | None = None
+
+
+class ContestRunSummary(BaseModel):
+    run_id: int
+    status: str
+    language: str | None = None
+    submitted_at: datetime | None = None
+
+
+class ContestCell(BaseModel):
+    problem_id: int
+    best_run: ContestRunSummary | None = None
+
+
+class ContestRow(BaseModel):
+    user_id: int
+    user_login: str
+    user_name: str | None = None
+    cells: list[ContestCell]
+
+
+class ContestReport(BaseModel):
+    contest_id: int
+    contest_name: str
+    problems: list[ContestProblem]
+    rows: list[ContestRow]
+
+
+class ContestReportsResponse(BaseModel):
+    contests: list[ContestReport]

--- a/backend/db.py
+++ b/backend/db.py
@@ -19,3 +19,11 @@ class Item(Base):
     id = Column(Integer, primary_key=True, index=True)
     title = Column(String, nullable=False)
     owner_id = Column(Integer, ForeignKey('users.id'))
+
+
+class ContestReportConfig(Base):
+    __tablename__ = 'contest_report_configs'
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey('users.id', ondelete='CASCADE'), unique=True, nullable=False)
+    contest_ids = Column(String, nullable=False, default='')

--- a/backend/migrations/versions/3a4e96d4e7d3_add_contest_report_config.py
+++ b/backend/migrations/versions/3a4e96d4e7d3_add_contest_report_config.py
@@ -1,0 +1,36 @@
+"""Add contest report config table
+
+Revision ID: 3a4e96d4e7d3
+Revises: 9e96c431b1e1
+Create Date: 2024-10-22 00:00:00.000000
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = '3a4e96d4e7d3'
+down_revision: str | Sequence[str] | None = '9e96c431b1e1'
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'contest_report_configs',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('user_id', sa.Integer(), nullable=False),
+        sa.Column('contest_ids', sa.String(), nullable=False, server_default=''),
+        sa.ForeignKeyConstraint(['user_id'], ['users.id'], ondelete='CASCADE'),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_index(op.f('ix_contest_report_configs_id'), 'contest_report_configs', ['id'], unique=False)
+    op.create_unique_constraint('uq_contest_report_configs_user_id', 'contest_report_configs', ['user_id'])
+
+
+def downgrade() -> None:
+    op.drop_constraint('uq_contest_report_configs_user_id', 'contest_report_configs', type_='unique')
+    op.drop_index(op.f('ix_contest_report_configs_id'), table_name='contest_report_configs')
+    op.drop_table('contest_report_configs')

--- a/backend/tests/test_contest_reports.py
+++ b/backend/tests/test_contest_reports.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+from test_app import _bearer, _register
+
+from backend.app.contest_reports import get_ejudge_client
+from backend.main import app
+
+
+class _FakeMaster:
+    def __init__(self, payloads: dict[int, dict[str, Any]]) -> None:
+        self._payloads = payloads
+
+    async def contest_status_json(self, *, contest_id: int) -> dict[str, Any]:
+        return self._payloads[contest_id]['status']
+
+    async def list_runs_json(self, *, contest_id: int, first_run: int = 0, **_: Any) -> dict[str, Any]:
+        assert first_run == 0
+        return self._payloads[contest_id]['runs']
+
+
+class _FakeClient:
+    def __init__(self, payloads: dict[int, dict[str, Any]]) -> None:
+        self.master = _FakeMaster(payloads)
+
+    async def aclose(self) -> None:  # pragma: no cover - required for compatibility
+        return None
+
+
+@pytest.fixture()
+def ejudge_override() -> AsyncIterator[None]:
+    sample_payloads: dict[int, dict[str, Any]] = {
+        301: {
+            'status': {
+                'ok': True,
+                'result': {
+                    'contest': {'id': 301, 'name': 'Demo Contest'},
+                    'problems': [
+                        {'id': 1, 'short_name': 'A', 'long_name': 'Alpha'},
+                        {'id': 2, 'short_name': 'B', 'long_name': 'Beta'},
+                    ],
+                },
+            },
+            'runs': {
+                'ok': True,
+                'result': {
+                    'runs': [
+                        {
+                            'run_id': 10,
+                            'prob_id': 1,
+                            'status_str': 'OK',
+                            'user_id': 100,
+                            'user_login': 'alice',
+                            'user_name': 'Alice',
+                            'lang_name': 'Python',
+                            'last_change_us': 1_000_000,
+                        },
+                        {
+                            'run_id': 11,
+                            'prob_id': 2,
+                            'status_str': 'PR',
+                            'user_id': 100,
+                            'user_login': 'alice',
+                            'user_name': 'Alice',
+                            'lang_name': 'C++',
+                            'last_change_us': 2_000_000,
+                        },
+                        {
+                            'run_id': 12,
+                            'prob_id': 1,
+                            'status_str': 'WA',
+                            'user_id': 101,
+                            'user_login': 'bob',
+                            'user_name': 'Bob',
+                            'lang_name': 'Python',
+                            'last_change_us': 3_000_000,
+                        },
+                    ]
+                },
+            },
+        }
+    }
+
+    async def _fake_client() -> AsyncIterator[_FakeClient]:
+        yield _FakeClient(sample_payloads)
+
+    app.dependency_overrides[get_ejudge_client] = _fake_client
+    try:
+        yield
+    finally:
+        app.dependency_overrides.pop(get_ejudge_client, None)
+
+
+def test_contest_config_defaults_to_empty(client) -> None:
+    tokens = _register(client, 'report@example.com', 'pw')
+    access = tokens['access_token']
+
+    response = client.get('/private/contest-config', headers=_bearer(access))
+    assert response.status_code == 200
+    assert response.json() == {'contest_ids': []}
+
+
+def test_update_contest_config_sorts_and_deduplicates(client) -> None:
+    tokens = _register(client, 'config@example.com', 'pw')
+    access = tokens['access_token']
+
+    response = client.put(
+        '/private/contest-config',
+        headers=_bearer(access),
+        json={'contest_ids': [302, 301, 302]},
+    )
+    assert response.status_code == 200
+    assert response.json() == {'contest_ids': [301, 302]}
+
+    follow_up = client.get('/private/contest-config', headers=_bearer(access))
+    assert follow_up.status_code == 200
+    assert follow_up.json() == {'contest_ids': [301, 302]}
+
+
+def test_contest_reports_return_highlighted_runs(client, ejudge_override) -> None:
+    tokens = _register(client, 'reports@example.com', 'pw')
+    access = tokens['access_token']
+
+    save = client.put(
+        '/private/contest-config',
+        headers=_bearer(access),
+        json={'contest_ids': [301]},
+    )
+    assert save.status_code == 200
+
+    response = client.get('/private/contest-reports', headers=_bearer(access))
+    assert response.status_code == 200
+    payload = response.json()
+
+    contests = payload['contests']
+    assert len(contests) == 1
+    contest = contests[0]
+    assert contest['contest_id'] == 301
+    assert contest['contest_name'] == 'Demo Contest'
+    assert [problem['short_name'] for problem in contest['problems']] == ['A', 'B']
+
+    rows = contest['rows']
+    assert [row['user_login'] for row in rows] == ['alice', 'bob']
+
+    alice = rows[0]
+    cell_a = alice['cells'][0]['best_run']
+    assert cell_a['status'] == 'OK'
+    assert cell_a['language'] == 'Python'
+    submitted = cell_a['submitted_at']
+    assert isinstance(submitted, str)
+    parsed_submitted = datetime.fromisoformat(submitted.replace('Z', '+00:00'))
+    assert parsed_submitted == datetime(1970, 1, 1, 0, 0, 1, tzinfo=UTC)
+
+    cell_b = alice['cells'][1]['best_run']
+    assert cell_b['status'] == 'PR'
+    assert cell_b['language'] == 'C++'
+
+    bob = rows[1]
+    assert all(cell['best_run'] is None for cell in bob['cells'])

--- a/backend/tests/test_contest_reports.py
+++ b/backend/tests/test_contest_reports.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from collections.abc import AsyncIterator
 from datetime import UTC, datetime
 from typing import Any
@@ -8,6 +9,8 @@ import pytest
 from test_app import _bearer, _register
 
 from backend.app.contest_reports import get_ejudge_client
+from backend.app.database import engine
+from backend.db import ContestReportConfig
 from backend.main import app
 
 
@@ -98,6 +101,21 @@ def ejudge_override() -> AsyncIterator[None]:
 def test_contest_config_defaults_to_empty(client) -> None:
     tokens = _register(client, 'report@example.com', 'pw')
     access = tokens['access_token']
+
+    response = client.get('/private/contest-config', headers=_bearer(access))
+    assert response.status_code == 200
+    assert response.json() == {'contest_ids': []}
+
+
+def test_contest_config_recovers_if_table_missing(client) -> None:
+    tokens = _register(client, 'missing-table@example.com', 'pw')
+    access = tokens['access_token']
+
+    async def _drop_table() -> None:
+        async with engine.begin() as conn:
+            await conn.run_sync(ContestReportConfig.__table__.drop, checkfirst=True)
+
+    asyncio.run(_drop_table())
 
     response = client.get('/private/contest-config', headers=_bearer(access))
     assert response.status_code == 200

--- a/frontend/private/contestReports.ts
+++ b/frontend/private/contestReports.ts
@@ -1,0 +1,102 @@
+export type ContestRunSummary = {
+  run_id: number;
+  status: string;
+  language?: string | null;
+  submitted_at?: string | null;
+};
+
+export type ContestCell = {
+  problem_id: number;
+  best_run: ContestRunSummary | null;
+};
+
+export type ContestRow = {
+  user_id: number;
+  user_login: string;
+  user_name?: string | null;
+  cells: ContestCell[];
+};
+
+export type ContestProblem = {
+  id: number;
+  short_name: string;
+  long_name?: string | null;
+};
+
+export type ContestReport = {
+  contest_id: number;
+  contest_name: string;
+  problems: ContestProblem[];
+  rows: ContestRow[];
+};
+
+export type ContestReportsResponse = {
+  contests: ContestReport[];
+};
+
+const STATUS_CLASSES: Record<string, string> = {
+  OK: 'bg-green-200 text-green-900 font-semibold',
+  AC: 'bg-yellow-200 text-yellow-900 font-semibold',
+  PR: 'bg-yellow-200 text-yellow-900 font-semibold',
+  SM: 'bg-yellow-200 text-yellow-900 font-semibold',
+};
+
+export function highlightClass(status?: string | null): string | null {
+  if (!status) {
+    return null;
+  }
+  const normalized = status.trim().toUpperCase();
+  return STATUS_CLASSES[normalized] ?? null;
+}
+
+export function hasHighlight(cell: ContestCell): boolean {
+  return Boolean(cell.best_run && highlightClass(cell.best_run.status));
+}
+
+export function formatTooltip(run: ContestRunSummary): string {
+  const parts: string[] = [];
+  if (run.language) {
+    parts.push(run.language);
+  }
+
+  if (run.submitted_at) {
+    const date = new Date(run.submitted_at);
+    if (!Number.isNaN(date.valueOf())) {
+      parts.push(date.toLocaleString());
+    }
+  }
+
+  parts.push(`run #${run.run_id}`);
+  return parts.join(' • ');
+}
+
+export function participantDisplayName(row: ContestRow): string {
+  const trimmedName = row.user_name?.trim();
+  if (trimmedName) {
+    if (trimmedName.toLowerCase() === row.user_login.toLowerCase()) {
+      return trimmedName;
+    }
+    return `${trimmedName} (${row.user_login})`;
+  }
+  return row.user_login;
+}
+
+export function parseContestInput(value: string): number[] {
+  const unique = new Set<number>();
+  value
+    .split(',')
+    .map((part) => part.trim())
+    .filter((part) => part.length > 0)
+    .forEach((part) => {
+      const numeric = Number(part);
+      if (Number.isInteger(numeric) && numeric > 0) {
+        unique.add(numeric);
+      }
+    });
+
+  return Array.from(unique).sort((a, b) => a - b);
+}
+
+export function formatContestInput(ids: number[]): string {
+  return ids.join(', ');
+}

--- a/frontend/private/index.html
+++ b/frontend/private/index.html
@@ -1,23 +1,34 @@
-<!-- frontend/private/index.html -->
 <!doctype html>
-<html lang="en">
+<html lang="ru">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Private Page</title>
+    <title>Отчёты по контестам</title>
     <link href="/src/style.css" rel="stylesheet" />
   </head>
-  <body class="bg-gray-50 text-gray-900">
-    <div class="max-w-md p-6 mx-auto">
-      <h1 class="text-2xl font-bold mb-4">Your Items</h1>
-      <ul id="item-list" class="mb-4 bg-white p-4 rounded border">
-        <!-- Items will be listed here -->
-      </ul>
-      <form id="item-form" class="flex">
-        <input id="item-title" type="text" placeholder="New item" required class="border p-1 flex-grow" />
-        <button type="submit" class="bg-blue-500 text-white px-3 py-1 ml-2 rounded">Add</button>
-      </form>
-      <p><a id="logout-link" href="/">Logout</a></p>
+  <body class="bg-gray-50 text-gray-900 min-h-screen">
+    <div class="max-w-5xl mx-auto p-6 space-y-6">
+      <header class="space-y-3">
+        <div class="flex items-center justify-between gap-4">
+          <h1 class="text-3xl font-bold">Отчёты по контестам</h1>
+          <a id="logout-link" href="/" class="text-sm text-blue-600 hover:underline">Выйти</a>
+        </div>
+        <form id="contest-config-form" class="flex flex-col gap-3 md:flex-row md:items-center">
+          <label for="contest-config" class="font-medium">Номера контестов</label>
+          <input
+            id="contest-config"
+            type="text"
+            placeholder="Например: 301, 302, 303"
+            class="flex-1 border border-gray-300 rounded px-3 py-2 shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-400"
+            autocomplete="off"
+          />
+          <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded shadow hover:bg-blue-700 transition">Сохранить и загрузить</button>
+        </form>
+        <p class="text-sm text-gray-600">Укажите номера контестов через запятую. Конфигурация сохранится для вашего аккаунта.</p>
+        <p id="status-message" class="text-sm text-gray-600"></p>
+      </header>
+
+      <section id="reports-section" class="space-y-6"></section>
     </div>
 
     <script type="module" src="/private/main.ts"></script>

--- a/frontend/private/main.ts
+++ b/frontend/private/main.ts
@@ -1,26 +1,40 @@
-// frontend/private/main.ts
 import '../src/style.css';
+import {
+  ContestReport,
+  ContestReportsResponse,
+  formatContestInput,
+  formatTooltip,
+  hasHighlight,
+  highlightClass,
+  parseContestInput,
+  participantDisplayName,
+} from './contestReports';
 
 const API_BASE = (import.meta as any).env?.VITE_API_BASE || 'http://localhost:8000';
-const itemList = document.getElementById('item-list') as HTMLUListElement;
-const itemForm = document.getElementById('item-form') as HTMLFormElement;
-const logoutLink = document.getElementById('logout-link');
-
 const accessToken = localStorage.getItem('accessToken');
 const refreshToken = localStorage.getItem('refreshToken');
 
-// Redirect to home if not logged in
+const configInput = document.getElementById('contest-config') as HTMLInputElement;
+const configForm = document.getElementById('contest-config-form') as HTMLFormElement;
+const statusMessage = document.getElementById('status-message') as HTMLParagraphElement;
+const reportsSection = document.getElementById('reports-section') as HTMLElement;
+const logoutLink = document.getElementById('logout-link');
+
 if (!accessToken) {
   window.location.href = '/';
 }
 
-// Helper: authorized fetch
+function setStatus(message: string, kind: 'info' | 'error' = 'info') {
+  statusMessage.textContent = message;
+  statusMessage.className = kind === 'error' ? 'text-sm text-red-600' : 'text-sm text-gray-600';
+}
+
 async function apiRequest(path: string, options: RequestInit = {}) {
   const headers = options.headers ? new Headers(options.headers) : new Headers();
   headers.set('Authorization', `Bearer ${localStorage.getItem('accessToken')}`);
   options.headers = headers;
+
   const response = await fetch(`${API_BASE}${path}`, options);
-  // If access token expired (401), attempt refresh
   if (response.status === 401 && refreshToken) {
     const refreshRes = await fetch(`${API_BASE}/auth/refresh`, {
       method: 'POST',
@@ -29,7 +43,6 @@ async function apiRequest(path: string, options: RequestInit = {}) {
     if (refreshRes.ok) {
       const data = await refreshRes.json();
       localStorage.setItem('accessToken', data.access_token);
-      // Retry original request with new token
       headers.set('Authorization', `Bearer ${data.access_token}`);
       return fetch(`${API_BASE}${path}`, options);
     }
@@ -37,49 +50,204 @@ async function apiRequest(path: string, options: RequestInit = {}) {
   return response;
 }
 
-// Fetch and display current items on page load
-async function loadItems() {
-  const res = await apiRequest('/items');
-  if (res.ok) {
-    const items = await res.json();
-    itemList.innerHTML = ''; // clear list
-    items.forEach((item: any) => {
-      const li = document.createElement('li');
-      li.textContent = item.title;
-      itemList.appendChild(li);
-    });
-  } else {
-    console.error('Failed to load items', res.status);
-    if (res.status === 401) {
-      alert('Session expired, please log in again');
-      localStorage.clear();
-      window.location.href = '/';
+async function fetchContestConfig(): Promise<number[]> {
+  const response = await apiRequest('/private/contest-config');
+  if (!response.ok) {
+    const detail = await safeDetail(response);
+    throw new Error(detail ?? 'Не удалось загрузить конфигурацию контестов.');
+  }
+  const payload = (await response.json()) as { contest_ids: number[] };
+  return payload.contest_ids ?? [];
+}
+
+async function saveContestConfig(ids: number[]): Promise<number[]> {
+  const response = await apiRequest('/private/contest-config', {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ contest_ids: ids }),
+  });
+  if (!response.ok) {
+    const detail = await safeDetail(response);
+    throw new Error(detail ?? 'Не удалось сохранить конфигурацию контестов.');
+  }
+  const payload = (await response.json()) as { contest_ids: number[] };
+  return payload.contest_ids ?? [];
+}
+
+async function fetchContestReports(): Promise<ContestReportsResponse> {
+  const response = await apiRequest('/private/contest-reports');
+  if (!response.ok) {
+    const detail = await safeDetail(response);
+    throw new Error(detail ?? 'Не удалось загрузить отчёты.');
+  }
+  return (await response.json()) as ContestReportsResponse;
+}
+
+async function safeDetail(response: Response): Promise<string | null> {
+  try {
+    const payload = await response.json();
+    if (payload && typeof payload.detail === 'string') {
+      return payload.detail;
     }
+  } catch (error) {
+    console.warn('Failed to parse error payload', error);
+  }
+  return null;
+}
+
+function renderReports(payload: ContestReportsResponse) {
+  reportsSection.innerHTML = '';
+  if (!payload.contests.length) {
+    const empty = document.createElement('p');
+    empty.className = 'text-gray-600';
+    empty.textContent = 'Нет данных для отображения. Сохраните конфигурацию, чтобы увидеть таблицы.';
+    reportsSection.appendChild(empty);
+    return;
+  }
+
+  payload.contests.forEach((contest) => {
+    reportsSection.appendChild(renderContestReport(contest));
+  });
+}
+
+function renderContestReport(contest: ContestReport): HTMLElement {
+  const wrapper = document.createElement('article');
+  wrapper.className = 'space-y-3';
+
+  const heading = document.createElement('div');
+  heading.className = 'flex flex-wrap items-baseline justify-between gap-2';
+
+  const title = document.createElement('h2');
+  title.className = 'text-2xl font-semibold';
+  title.textContent = `${contest.contest_name} (#${contest.contest_id})`;
+  heading.appendChild(title);
+
+  wrapper.appendChild(heading);
+
+  if (!contest.problems.length) {
+    const noProblems = document.createElement('p');
+    noProblems.className = 'text-gray-600';
+    noProblems.textContent = 'В этом контесте нет задач для отображения.';
+    wrapper.appendChild(noProblems);
+    return wrapper;
+  }
+
+  const table = document.createElement('table');
+  table.className = 'w-full border border-gray-300 bg-white text-sm shadow-sm';
+
+  const thead = document.createElement('thead');
+  const headerRow = document.createElement('tr');
+
+  const participantHeader = document.createElement('th');
+  participantHeader.textContent = 'Участник';
+  participantHeader.className = 'border border-gray-300 bg-gray-100 px-3 py-2 text-left';
+  headerRow.appendChild(participantHeader);
+
+  contest.problems.forEach((problem) => {
+    const th = document.createElement('th');
+    th.textContent = problem.short_name;
+    th.title = problem.long_name ?? '';
+    th.className = 'border border-gray-300 bg-gray-100 px-3 py-2 text-center';
+    headerRow.appendChild(th);
+  });
+
+  thead.appendChild(headerRow);
+  table.appendChild(thead);
+
+  const tbody = document.createElement('tbody');
+  if (!contest.rows.length) {
+    const row = document.createElement('tr');
+    const cell = document.createElement('td');
+    cell.colSpan = contest.problems.length + 1;
+    cell.className = 'border border-gray-200 px-3 py-4 text-center text-gray-600';
+    cell.textContent = 'Нет участников с отправленными решениями.';
+    row.appendChild(cell);
+    tbody.appendChild(row);
+  } else {
+    contest.rows.forEach((rowData) => {
+      const row = document.createElement('tr');
+      const participantCell = document.createElement('td');
+      participantCell.className = 'border border-gray-200 px-3 py-2 align-middle';
+      participantCell.textContent = participantDisplayName(rowData);
+      row.appendChild(participantCell);
+
+      rowData.cells.forEach((cellData) => {
+        const td = document.createElement('td');
+        td.className = 'border border-gray-200 px-2 py-1 text-center align-middle';
+
+        if (hasHighlight(cellData) && cellData.best_run) {
+          const css = highlightClass(cellData.best_run.status);
+          if (css) {
+            css.split(' ').forEach((klass) => td.classList.add(klass));
+          }
+          td.title = formatTooltip(cellData.best_run);
+          const symbol = document.createElement('span');
+          symbol.textContent = '+';
+          symbol.className = 'text-lg';
+          td.appendChild(symbol);
+        }
+
+        row.appendChild(td);
+      });
+
+      tbody.appendChild(row);
+    });
+  }
+
+  table.appendChild(tbody);
+  wrapper.appendChild(table);
+  return wrapper;
+}
+
+async function refreshReports() {
+  try {
+    setStatus('Загружаем отчёты…');
+    const payload = await fetchContestReports();
+    renderReports(payload);
+    setStatus('Отчёты обновлены.');
+  } catch (error) {
+    console.error(error);
+    setStatus(error instanceof Error ? error.message : 'Не удалось обновить отчёты.', 'error');
   }
 }
 
-// Handle new item form submission
-itemForm.onsubmit = async (e) => {
-  e.preventDefault();
-  const titleInput = document.getElementById('item-title') as HTMLInputElement;
-  const title = titleInput.value;
-  const res = await apiRequest('/items', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ title }),
-  });
-  if (res.ok) {
-    titleInput.value = '';
-    await loadItems(); // refresh list to show new item
-  } else {
-    alert('Failed to add item');
+async function bootstrap() {
+  try {
+    const ids = await fetchContestConfig();
+    configInput.value = formatContestInput(ids);
+    if (!ids.length) {
+      renderReports({ contests: [] });
+      setStatus('Укажите номера контестов и нажмите «Сохранить и загрузить».');
+      return;
+    }
+    await refreshReports();
+  } catch (error) {
+    console.error(error);
+    setStatus(error instanceof Error ? error.message : 'Не удалось загрузить конфигурацию.', 'error');
   }
-};
+}
 
-// Handle logout: clear tokens
-logoutLink!.onclick = () => {
+configForm.addEventListener('submit', async (event) => {
+  event.preventDefault();
+  const ids = parseContestInput(configInput.value);
+  if (!ids.length) {
+    setStatus('Добавьте хотя бы один номер контеста перед сохранением.', 'error');
+    renderReports({ contests: [] });
+    return;
+  }
+
+  try {
+    const saved = await saveContestConfig(ids);
+    configInput.value = formatContestInput(saved);
+    await refreshReports();
+  } catch (error) {
+    console.error(error);
+    setStatus(error instanceof Error ? error.message : 'Не удалось сохранить конфигурацию.', 'error');
+  }
+});
+
+logoutLink?.addEventListener('click', () => {
   localStorage.clear();
-};
+});
 
-// Initial load
-loadItems();
+bootstrap();

--- a/frontend/private/main.ts
+++ b/frontend/private/main.ts
@@ -14,11 +14,19 @@ const API_BASE = (import.meta as any).env?.VITE_API_BASE || 'http://localhost:80
 const accessToken = localStorage.getItem('accessToken');
 const refreshToken = localStorage.getItem('refreshToken');
 
-const configInput = document.getElementById('contest-config') as HTMLInputElement;
-const configForm = document.getElementById('contest-config-form') as HTMLFormElement;
-const statusMessage = document.getElementById('status-message') as HTMLParagraphElement;
-const reportsSection = document.getElementById('reports-section') as HTMLElement;
-const logoutLink = document.getElementById('logout-link');
+let configInput: HTMLInputElement;
+let configForm: HTMLFormElement;
+let statusMessage: HTMLParagraphElement;
+let reportsSection: HTMLElement;
+let logoutLink: HTMLAnchorElement | null;
+
+function requireElement<T extends HTMLElement>(id: string): T {
+  const element = document.getElementById(id);
+  if (!element) {
+    throw new Error(`Element with id "${id}" was not found on the page.`);
+  }
+  return element as T;
+}
 
 if (!accessToken) {
   window.location.href = '/';
@@ -227,27 +235,47 @@ async function bootstrap() {
   }
 }
 
-configForm.addEventListener('submit', async (event) => {
-  event.preventDefault();
-  const ids = parseContestInput(configInput.value);
-  if (!ids.length) {
-    setStatus('Добавьте хотя бы один номер контеста перед сохранением.', 'error');
-    renderReports({ contests: [] });
+function setupDomReferences() {
+  configInput = requireElement<HTMLInputElement>('contest-config');
+  configForm = requireElement<HTMLFormElement>('contest-config-form');
+  statusMessage = requireElement<HTMLParagraphElement>('status-message');
+  reportsSection = requireElement<HTMLElement>('reports-section');
+  logoutLink = document.getElementById('logout-link') as HTMLAnchorElement | null;
+}
+
+function registerEventListeners() {
+  configForm.addEventListener('submit', async (event) => {
+    event.preventDefault();
+    const ids = parseContestInput(configInput.value);
+    if (!ids.length) {
+      setStatus('Добавьте хотя бы один номер контеста перед сохранением.', 'error');
+      renderReports({ contests: [] });
+      return;
+    }
+
+    try {
+      const saved = await saveContestConfig(ids);
+      configInput.value = formatContestInput(saved);
+      await refreshReports();
+    } catch (error) {
+      console.error(error);
+      setStatus(error instanceof Error ? error.message : 'Не удалось сохранить конфигурацию.', 'error');
+    }
+  });
+
+  logoutLink?.addEventListener('click', () => {
+    localStorage.clear();
+  });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  try {
+    setupDomReferences();
+  } catch (error) {
+    console.error(error);
     return;
   }
 
-  try {
-    const saved = await saveContestConfig(ids);
-    configInput.value = formatContestInput(saved);
-    await refreshReports();
-  } catch (error) {
-    console.error(error);
-    setStatus(error instanceof Error ? error.message : 'Не удалось сохранить конфигурацию.', 'error');
-  }
+  registerEventListeners();
+  void bootstrap();
 });
-
-logoutLink?.addEventListener('click', () => {
-  localStorage.clear();
-});
-
-bootstrap();

--- a/frontend/src/contestReports.test.ts
+++ b/frontend/src/contestReports.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from 'vitest';
+
+import { formatContestInput, formatTooltip, hasHighlight, highlightClass, parseContestInput, participantDisplayName } from '../private/contestReports';
+
+const GREEN_CLASS = 'bg-green-200 text-green-900 font-semibold';
+const YELLOW_CLASS = 'bg-yellow-200 text-yellow-900 font-semibold';
+
+describe('contest report helpers', () => {
+  test('parseContestInput trims, filters and sorts values', () => {
+    expect(parseContestInput('302, 301, 302, -1, abc, 400')).toEqual([301, 302, 400]);
+    expect(parseContestInput('')).toEqual([]);
+  });
+
+  test('formatContestInput joins ids with comma and space', () => {
+    expect(formatContestInput([301, 302])).toBe('301, 302');
+  });
+
+  test('highlightClass maps supported statuses', () => {
+    expect(highlightClass('OK')).toBe(GREEN_CLASS);
+    expect(highlightClass('ok')).toBe(GREEN_CLASS);
+    expect(highlightClass('PR')).toBe(YELLOW_CLASS);
+    expect(highlightClass('WA')).toBeNull();
+  });
+
+  test('hasHighlight detects highlighted cells', () => {
+    expect(
+      hasHighlight({
+        problem_id: 1,
+        best_run: { run_id: 1, status: 'AC', language: 'Python', submitted_at: null },
+      })
+    ).toBe(true);
+    expect(hasHighlight({ problem_id: 1, best_run: null })).toBe(false);
+  });
+
+  test('formatTooltip combines language, date and run id', () => {
+    const tooltip = formatTooltip({ run_id: 10, status: 'OK', language: 'Python', submitted_at: '1970-01-01T00:00:01Z' });
+    expect(tooltip).toContain('Python');
+    expect(tooltip).toContain('run #10');
+  });
+
+  test('participantDisplayName prefers full name', () => {
+    expect(
+      participantDisplayName({
+        user_id: 1,
+        user_login: 'ivanov',
+        user_name: 'Иван Иванов',
+        cells: [],
+      })
+    ).toBe('Иван Иванов (ivanov)');
+
+    expect(
+      participantDisplayName({
+        user_id: 2,
+        user_login: 'petrov',
+        user_name: 'petrov',
+        cells: [],
+      })
+    ).toBe('petrov');
+
+    expect(
+      participantDisplayName({
+        user_id: 3,
+        user_login: 'sidorov',
+        user_name: undefined,
+        cells: [],
+      })
+    ).toBe('sidorov');
+  });
+});


### PR DESCRIPTION
## Summary
- add contest report configuration model and API endpoints for saving IDs and retrieving aggregated ejudge results
- build a contest reports view in the private frontend with persisted config, highlighted verdicts, and tooltips for runs
- cover the new backend endpoints and frontend helpers with targeted tests and add a migration for the stored configuration

## Testing
- make test-backend
- make test-frontend-unit

------
https://chatgpt.com/codex/tasks/task_e_68ebc3a777a883268e1d12efdc653e35